### PR TITLE
Corrected location of page-images factory in Gemspec

### DIFF
--- a/refinerycms-page-images.gemspec
+++ b/refinerycms-page-images.gemspec
@@ -70,7 +70,6 @@ Gem::Specification.new do |s|
     'spec/requests',
     'spec/requests/attach_page_images_spec.rb',
     'spec/support',
-    'spec/support/refinery',
-    'spec/support/refinery/factories.rb'
+    'spec/factories/page-images.rb'
   ]
 end


### PR DESCRIPTION
The current rails-3-1 branch has a broken gemspec, that points to files that does not exist. This commit fixes the gemspec.
