### PR TITLE
Deleting all images from a page

### DIFF
--- a/lib/refinery/page_images/extension.rb
+++ b/lib/refinery/page_images/extension.rb
@@ -14,9 +14,16 @@ module Refinery
         module_eval do
           def images_attributes=(data)
             ids_to_keep = data.map{|i, d| d['image_page_id']}.compact
-            self.image_pages.where(
-              Refinery::ImagePage.arel_table[:id].not_in(ids_to_keep)
-            ).destroy_all
+
+            image_pages_to_delete = if ids_to_keep.empty?
+              self.image_pages
+            else
+              self.image_pages.where(
+                Refinery::ImagePage.arel_table[:id].not_in(ids_to_keep)
+              )
+            end
+
+            image_pages_to_delete.destroy_all
 
             data.each do |i, image_data|
               image_page_id, image_id, caption =

--- a/spec/models/refinery/page_spec.rb
+++ b/spec/models/refinery/page_spec.rb
@@ -21,7 +21,7 @@ module Refinery
         page.images.count.should == 1
       end
 
-      it "deletes images" do
+      it "deletes specific images" do
         page = Factory(:page)
         images = [Factory(:image), Factory(:image)]
         page.images = images
@@ -34,6 +34,16 @@ module Refinery
         })
 
         page.images.should eq([images.first])
+      end
+
+      it "deletes all images" do
+        page = Factory(:page)
+        images = [Factory(:image), Factory(:image)]
+        page.images = images
+
+        page.update_attributes(:images_attributes => {"0" => {"id"=>""}})
+
+        page.images.should be_empty
       end
 
       it "reorders images" do


### PR DESCRIPTION
Includes/depends on #53, but I sent them as seperate pull requests so we could discuss if necessary.

When I refactored stuff in #50, I thought using `not_in([])` would mean all records, but apparently it means none (at least in sqlite). This explicitly checks if the set is empty, and if so, destroys all associated image_pages.
