### PR TITLE
allow 'Image' tab to be renamed in the translation - i.e to slideshow

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
     plugins:
       refinery_page_images:
         title: Page Images
+        tab_name: Images
         description: Page Images allows you to relate one or more images to any page in Refinery which makes it really easy for you to create simple image galleries with lightbox style popups on the front end page views.
     js:
       admin:
@@ -14,3 +15,4 @@ en:
         tabs:
           images_bar:
             add: Add Image
+               

--- a/lib/refinery/page_images/engine.rb
+++ b/lib/refinery/page_images/engine.rb
@@ -8,7 +8,7 @@ module Refinery
       engine_name :refinery_page_images
 
       def self.register(tab)
-        tab.name = "images"
+        tab.name = ::I18n.t(:'refinery.plugins.refinery_page_images.tab_name')
         tab.partial = "/refinery/admin/pages/tabs/images"
       end
 


### PR DESCRIPTION
PageImages is particularly useful for slideshows & Galleries etc, this minor change saves developers grief when they just want to rename the 'Images' tab to make it meaningful for clients. 
Just an override of locales (:tab_name) and it's now done.
