### PR TITLE
fix invalid byte sequence in US-ASCII

### DIFF
--- a/app/assets/javascripts/refinery/page-image-picker.js.erb
+++ b/app/assets/javascripts/refinery/page-image-picker.js.erb
@@ -1,3 +1,4 @@
+<%# encoding: utf-8 %>
 $(document).ready(function(){
   $('#custom_images_tab a').click(function(){
     if (!(picker = $('#page_image_picker')).data('size-applied')){


### PR DESCRIPTION
Hi

I have similar problem described here https://github.com/refinery/refinerycms/pull/1773

"If translation .yml files have UTF-8 characters, asset precompilation will fail because some javascript files contain ::I18n.t. Adding <%# encoding: utf-8 %> to the top of those files solves the problem."

Please merge with master

Martin
