### PR TITLE
Update refinerycms-page-images.gemspec for refinerycms-pages 2.1.0

### DIFF
--- a/refinerycms-page-images.gemspec
+++ b/refinerycms-page-images.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = %q{refinerycms-page-images}
-  s.version           = %q{2.1.0.dev}
+  s.version           = %q{2.1.0}
   s.description       = %q{Attach images to pages ins Refinery CMS}
   s.summary           = %q{Page Images extension for Refinery CMS}
   s.email             = %q{info@refinerycms.com}
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
   s.files             = `git ls-files`.split("\n")
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
-  s.add_dependency    'refinerycms-pages', '~> 2.1.0.dev'
+  s.add_dependency    'refinerycms-pages', '~> 2.1.0'
 end


### PR DESCRIPTION
I removed the .dev in the gemspec for the version and the refinerycms-pages 2.1.0 dependency.
