### PR TITLE
Remove attr_accessible statements and the protected_attributes gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ git 'https://github.com/refinery/refinerycms.git', branch: 'master' do
   gem 'refinerycms-testing', group: :test
 end
 gem 'refinerycms-i18n', github: 'refinery/refinerycms-i18n', branch: 'master'
-gem 'protected_attributes'
 gem 'globalize', github: 'globalize/globalize', branch: 'master'
 gem 'seo_meta', github: 'parndt/seo_meta', branch: 'master'
 gem 'mime-types', '~> 1.16'

--- a/app/models/refinery/image_page.rb
+++ b/app/models/refinery/image_page.rb
@@ -5,9 +5,5 @@ module Refinery
     belongs_to :page, :polymorphic => true
 
     translates :caption if self.respond_to?(:translates)
-
-    attr_accessible :image_id, :position, :locale
-    self.translation_class.send :attr_accessible, :locale
-
   end
 end

--- a/lib/refinery/page_images/extension.rb
+++ b/lib/refinery/page_images/extension.rb
@@ -46,8 +46,6 @@ module Refinery
         end
 
         include Refinery::PageImages::Extension::InstanceMethods
-
-        attr_accessible :images_attributes
       end
 
       module InstanceMethods


### PR DESCRIPTION
refinerycms-page-images was broken because of the protected_attributes change in refinery master..
