### PR TITLE
Dependency on Globalize 5.0

### DIFF
--- a/refinerycms-page-images.gemspec
+++ b/refinerycms-page-images.gemspec
@@ -14,5 +14,5 @@ Gem::Specification.new do |s|
 
   s.add_dependency    'refinerycms-pages', '~> 3.0.0'
   s.add_dependency    'decorators',        '~> 2.0.0'
-  s.add_dependency    'globalize',         '~> 4.0'
+  s.add_dependency    'globalize',         '~> 5.0'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require File.expand_path("../dummy/config/environment", __FILE__)
 
 require 'rspec/rails'
 require 'capybara/rspec'
-require 'factory_girl_rails'
+require 'factory_girl'
 
 Rails.backtrace_cleaner.remove_silencers!
 


### PR DESCRIPTION
No need to use factory_girl_rails anymore.
Refinerycms-testing will load all your factories.