### PR TITLE
Bugfix/touch page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
-
-git "https://github.com/refinery/refinerycms", branch: "3-0-stable" do
+git 'https://github.com/refinery/refinerycms', branch: '3-0-stable' do
   gem 'refinerycms'
 
   group :development, :test do

--- a/app/models/refinery/image_page.rb
+++ b/app/models/refinery/image_page.rb
@@ -2,7 +2,7 @@ module Refinery
   class ImagePage < Refinery::Core::BaseModel
 
     belongs_to :image
-    belongs_to :page, :polymorphic => true
+    belongs_to :page, polymorphic: true, touch: true
 
     translates :caption
   end

--- a/spec/factories/page-images.rb
+++ b/spec/factories/page-images.rb
@@ -6,4 +6,9 @@ FactoryGirl.define do
   factory :blog_post_with_image, :parent => :blog_post do
     after(:create) { |b| b.image_pages.create(image: FactoryGirl.create(:image)) }
   end if defined? Refinery::Blog::Post
+
+  factory :image_page, class: Refinery::ImagePage do
+    image
+    page
+  end
 end

--- a/spec/models/refinery/image_page_spec.rb
+++ b/spec/models/refinery/image_page_spec.rb
@@ -5,10 +5,14 @@ module Refinery
     let!(:image_page) { FactoryGirl.create(:image_page) }
 
     describe "touching" do
+      let(:original_updated_at) { 1.day.ago }
+      let(:page) { image_page.page }
+
+      before { page.update_column(:updated_at, original_updated_at) }
+
       it "updates a page" do
-        image_page.page.update_column(:updated_at, 1.day.ago)
-        image_page.touch
-        expect(image_page.page.reload.updated_at).to be_within(3.seconds).of(Time.current)
+        expect { image_page.touch }.to change { page.reload.updated_at }
+                                   .to be_within(3.seconds).of(Time.current)
       end
     end
   end

--- a/spec/models/refinery/image_page_spec.rb
+++ b/spec/models/refinery/image_page_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+module Refinery
+  describe ImagePage, type: :model do
+    let!(:image_page) { FactoryGirl.create(:image_page) }
+
+    describe "touching" do
+      it "updates a page" do
+        image_page.page.update_column(:updated_at, 1.day.ago)
+        image_page.touch
+        expect(image_page.page.reload.updated_at).to be_within(3.seconds).of(Time.current)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We should touch the Page or BlogPost record when we do a manipulation on ImagePage record in order to be able to invalidate cache in Page or BlogPost record.