### PR TITLE
belongs_to :page is now optional

### DIFF
--- a/app/models/refinery/image_page.rb
+++ b/app/models/refinery/image_page.rb
@@ -2,7 +2,7 @@ module Refinery
   class ImagePage < Refinery::Core::BaseModel
 
     belongs_to :image
-    belongs_to :page, polymorphic: true, touch: true
+    belongs_to :page, polymorphic: true, touch: true, optional: true
 
     translates :caption
 


### PR DESCRIPTION
because this extension can be use with another extension than page